### PR TITLE
added screen shake for taking damage and falling

### DIFF
--- a/player_cam.gd
+++ b/player_cam.gd
@@ -1,5 +1,9 @@
 extends Camera2D
 
+# Screen shake variables
+var shake_strength: float = 0.0
+var shake_decay: float = 5.0
+var shake_amount: float = 0.0
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
@@ -23,3 +27,18 @@ func _process(delta: float) -> void:
 		limit_smoothed = true
 	if not position_smoothing_enabled:
 		position_smoothing_enabled = true
+	
+	# Apply screen shake
+	if shake_strength > 0:
+		shake_strength = max(shake_strength - shake_decay * delta, 0)
+		offset = Vector2(
+			randf_range(-shake_strength, shake_strength),
+			randf_range(-shake_strength, shake_strength)
+		)
+	else:
+		offset = Vector2.ZERO
+
+# Call this function to trigger screen shake
+func apply_shake(strength: float = 10.0, decay: float = 5.0) -> void:
+	shake_strength = strength
+	shake_decay = decay


### PR DESCRIPTION
Added Screen Shake Feature

- Screen shakes when the player takes damage (strength: 3.0)
- Screen shakes when the player lands after being airborne for more than 1.2 seconds (strength: 5.0)
- Airborne timer only counts when truly in the air (excludes wall sliding)

Files modified:

- player_cam.gd: Added shake variables and shake system with apply_shake() method and decay logic
- player.gd: Added airborne time tracking and shake triggers for damage and hard landings